### PR TITLE
Fixed composer.json syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.2"
     },
     "autoload": {
-        "psr-0": { "MarcW": "bundles" }
+        "psr-0": { "MarcW\\Bundle\\WurstBundle": "" }
     },
-    "target-dir": "bundles/MarcW/Bundle/WurstBundle"
+    "target-dir": "MarcW/Bundle/WurstBundle"
 }


### PR DESCRIPTION
I've fixed composer.json syntax to allow people installing the bundle with composer.
