### PR TITLE
Explain how to add github as a repository when installing with composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Add MarcWWurstBundle in your composer.json:
 }
 ```
 
+Then add its github as a composer repository:
+
+```
+{
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/marcw/MarcWWurstBundle"
+        }
+    ]
+}
+```
+
 Now tell composer to download the bundle by running the command:
 
 ``` bash


### PR DESCRIPTION
I've added instructions to add github as a repository to allow people installing the bundle with composer.

You can submit the bundle to packagist and it will work without adding these lines. In that case you can reject this pull request. :)
