### PR TITLE
Add sf4/sf5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language: php
+sudo: false
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    - $HOME/symfony-bridge/.phpunit
+
+env:
+  global:
+    - SYMFONY_DEPRECATIONS_HELPER=max[direct]=0
+    - STABILITY="stable"
+
+matrix:
+  fast_finish: true
+  include:
+    # Minimum supported dependencies with the latest and oldest PHP version
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
+    - php: 5.6
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
+
+      # Test the latest stable release
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+
+    - php: 7.4
+      env: SYMFONY_VERSION="^3.4"
+    - php: 7.4
+      env: SYMFONY_VERSION="^4.0"
+    - php: 7.4
+      env: SYMFONY_VERSION="^5.0"
+
+      # Latest commit to master
+    - php: 7.4
+      env: STABILITY="dev"
+
+  allow_failures:
+    # Dev-master is allowed to fail.
+    - env: STABILITY="dev"
+
+before_install:
+  - if [ "$STABILITY" != "" ]; then composer config minimum-stability ${STABILITY}; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/flex; composer config extra.symfony.require ${SYMFONY_VERSION} || true; fi
+
+install:
+  - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
+  - ./vendor/bin/simple-phpunit install
+
+script:
+  - composer validate --strict --no-check-lock
+  - ./vendor/bin/simple-phpunit --bootstrap vendor/autoload.php Tests/

--- a/Command/WurstCommand.php
+++ b/Command/WurstCommand.php
@@ -3,6 +3,7 @@
 namespace MarcW\Bundle\WurstBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,8 +15,15 @@ use Symfony\Component\Finder\SplFileInfo;
  *
  * @author Marc Weistroff <marc.weistroff@gmail.com>
  */
-class WurstCommand extends ContainerAwareCommand
+class WurstCommand extends Command
 {
+    /**
+     * @var integer
+     *
+     * No error
+     */
+    const NO_ERROR = 0;
+
     /**
      * @var integer
      *
@@ -92,6 +100,8 @@ class WurstCommand extends ContainerAwareCommand
                 $output->write($option);
             }
         }
+
+        return self::NO_ERROR;
     }
 
     /**

--- a/DependencyInjection/MarcWWurstExtension.php
+++ b/DependencyInjection/MarcWWurstExtension.php
@@ -1,0 +1,16 @@
+<?php
+namespace MarcW\Bundle\WurstBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+class MarcWWurstExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/MarcWWurstBundle.php
+++ b/MarcWWurstBundle.php
@@ -2,8 +2,17 @@
 
 namespace MarcW\Bundle\WurstBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class MarcWWurstBundle extends Bundle
 {
+    public function getContainerExtension()
+    {
+        if (!class_exists('Symfony\Component\DependencyInjection\Extension\Extension')) {
+            $this->extension = false;
+        }
+
+        return parent::getContainerExtension();
+    }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service class="MarcW\Bundle\WurstBundle\Command\WurstCommand" id="MarcW\Bundle\WurstBundle\Command\WurstCommand">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>

--- a/Tests/Command/WurstCommandTestCase.php
+++ b/Tests/Command/WurstCommandTestCase.php
@@ -2,14 +2,19 @@
 
 namespace MarcW\Bundle\WurstBundle\Tests\Command;
 
+use MarcW\Bundle\WurstBundle\MarcWWurstBundle;
+use Nyholm\BundleTest\BaseBundleTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use MarcW\Bundle\WurstBundle\Command\WurstCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class WurstCommandTestCase extends \PHPUnit_Framework_TestCase
+class WurstCommandTestCase extends BaseBundleTestCase
 {
+    use SetUpTearDownTrait;
+
     protected $defaultWurst = 'classic';
     protected $wurstResourcesDirectory;
     protected $sideResourcesDirectory;
@@ -18,7 +23,7 @@ class WurstCommandTestCase extends \PHPUnit_Framework_TestCase
     protected $wurstTypes;
     protected $sides;
 
-    public function __construct()
+    private function doSetUp()
     {
         $resourceDirectory = $this->getResourceDirectory();
         $this->wurstResourcesDirectory = $resourceDirectory.'wurst/';
@@ -31,6 +36,12 @@ class WurstCommandTestCase extends \PHPUnit_Framework_TestCase
         $this->sides = $this->findFilenamesFromGivenDirectory($this->sideResourcesDirectory);
     }
 
+    protected function getBundleClass()
+    {
+        return MarcWWurstBundle::class;
+    }
+
+
     protected function getResourceDirectory()
     {
         $sourceDirectory = __DIR__.'/../../';
@@ -41,8 +52,10 @@ class WurstCommandTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setCommand()
     {
-        $mockedKernel = $this->getMock('Symfony\\Component\\HttpKernel\\Kernel', array(), array(), '', false);
-        $application = new Application($mockedKernel);
+        $kernel = $this->createKernel();
+        $this->bootKernel();
+
+        $application = new Application($kernel);
         $application->add(new WurstCommand());
 
         $this->command = $application->find('wurst:print');

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     "autoload": {
         "psr-0": { "MarcW\\Bundle\\WurstBundle": "" }
     },
-    "target-dir": "MarcW/Bundle/WurstBundle"
+    "target-dir": "MarcW/Bundle/WurstBundle",
+    "require-dev": {
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "nyholm/symfony-bundle-test": "dev-master",
+        "symfony/console": "^3.0 || ^4.0 || ^5.0"
+    }
 }


### PR DESCRIPTION
This PR aims to allow Symfony 4 and Symfony 5 compatibility (although the bundle is already compatible with Symfony 4, the command is currently not automatically registered).